### PR TITLE
fixing bug on variants download when accessing from main page

### DIFF
--- a/variants/download_all.php
+++ b/variants/download_all.php
@@ -90,7 +90,7 @@ include_once('../common.php');
 	  $query = "SELECT GeneName,Sequence FROM T_Ensembl LEFT JOIN T_Mutations on T_Ensembl.EnsPID=T_Mutations.EnsPID WHERE T_Mutations.Source RLIKE :source AND T_Mutations.`gene name` RLIKE :name AND T_Mutations.mut_description RLIKE :type AND T_Mutations.tumour_site IN (" . $plist . ");";
   }
   else {
-	  $query = "SELECT GeneName,Sequence FROM T_Ensembl LEFT JOIN T_Mutations on T_Ensembl.EnsPID=T_Mutations.EnsPID AND T_Mutations.tumour_site IN (" . $plist . ");";
+	  $query = "SELECT GeneName,Sequence FROM T_Ensembl LEFT JOIN T_Mutations on T_Ensembl.EnsPID=T_Mutations.EnsPID WHERE T_Mutations.tumour_site IN (" . $plist . ");";
   }
   }
   else

--- a/variants/download_all.php
+++ b/variants/download_all.php
@@ -86,11 +86,18 @@ include_once('../common.php');
   $tissue_array = explode(',', $tissues);
 
   $plist = implode("','", $tissue_array);
-  $query = "SELECT GeneName,Sequence FROM T_Ensembl LEFT JOIN T_Mutations on T_Ensembl.EnsPID=T_Mutations.EnsPID WHERE T_Mutations.Source RLIKE :source AND T_Mutations.`gene name` RLIKE :name AND T_Mutations.mut_description RLIKE :type AND T_Mutations.tumour_site IN (" . $plist . ") LIMIT 10000;";
+  if (isset($_GET['variant_search'])){
+	  $query = "SELECT GeneName,Sequence FROM T_Ensembl LEFT JOIN T_Mutations on T_Ensembl.EnsPID=T_Mutations.EnsPID WHERE T_Mutations.Source RLIKE :source AND T_Mutations.`gene name` RLIKE :name AND T_Mutations.mut_description RLIKE :type AND T_Mutations.tumour_site IN (" . $plist . ");";
+  }
+  else {
+	  $query = "SELECT GeneName,Sequence FROM T_Ensembl LEFT JOIN T_Mutations on T_Ensembl.EnsPID=T_Mutations.EnsPID AND T_Mutations.tumour_site IN (" . $plist . ");";
+  }
   }
   else
   {
-  $query = "SELECT GeneName,Sequence FROM T_Ensembl LEFT JOIN T_Mutations on T_Ensembl.EnsPID=T_Mutations.EnsPID WHERE  T_Mutations.Source RLIKE :source AND T_Mutations.`gene name` RLIKE :name AND T_Mutations.mut_description RLIKE :type LIMIT 10000;";
+  if (isset($_GET['variant_search'])){
+  	$query = "SELECT GeneName,Sequence FROM T_Ensembl LEFT JOIN T_Mutations on T_Ensembl.EnsPID=T_Mutations.EnsPID WHERE  T_Mutations.Source RLIKE :source AND T_Mutations.`gene name` RLIKE :name AND T_Mutations.mut_description RLIKE :type;";
+  }
   }
 
 


### PR DESCRIPTION
Currently, there is a bug where upon selecting "View Proteins" from the main page and then clicking "Download these Variants" on the variants page, the downloaded file is empty. I believe the following changes will fix that problem. I also removed the artificial limit of 10,000 variants on variant downloads, which may increase download times for really large variant sets, but will return the full complete set.
